### PR TITLE
feat: add GitHub repository link to navbar

### DIFF
--- a/src/app-data.ts
+++ b/src/app-data.ts
@@ -1,0 +1,5 @@
+const appData = {
+  GITHUB_REPOSITORY_URL: "https://github.com/ParachuteTeam/Parachute",
+};
+
+export default appData;

--- a/src/components/section/Navbar.tsx
+++ b/src/components/section/Navbar.tsx
@@ -3,6 +3,9 @@ import { useSession, signOut } from "next-auth/react";
 import Image from "next/image";
 import OnHover from "../ui/OnHover";
 import Link from "next/link";
+import appData from "../../app-data";
+import { HiOutlineExternalLink } from "react-icons/hi";
+import React from "react";
 
 const Navbar = () => {
   const router = useRouter();
@@ -20,7 +23,7 @@ const Navbar = () => {
 
   return (
     <div className="sticky top-0 flex w-full justify-center bg-white px-4 py-3 md:px-12 md:py-4">
-      <div className="mx-auto flex max-w-[1200px] grow text-3xl font-bold">
+      <div className="mx-auto flex max-w-[1200px] grow items-center gap-4 font-bold md:gap-8">
         <div className="grow">
           <Link
             className="max-w-[140px] grow cursor-pointer text-2xl font-bold md:text-3xl"
@@ -29,6 +32,15 @@ const Navbar = () => {
             Parachute
           </Link>
         </div>
+        <a
+          className="flex flex-row items-center gap-0.5 font-normal text-gray-500"
+          href={appData.GITHUB_REPOSITORY_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Github
+          <HiOutlineExternalLink />
+        </a>
         {session && (
           <OnHover
             content={


### PR DESCRIPTION
Simply adds a GitHub link (fixes #55):

<img width="259" alt="Screenshot 2023-06-28 at 2 32 12 PM" src="https://github.com/ParachuteTeam/Parachute/assets/30245379/250a0f94-a745-4b55-aa8e-20a7c73b9a34">

Design notes:

- I consider the navigation bar the most suitable place to put the link for now;
- The GitHub link should be classified as secondary information, so it should be placed on the right instead of just beside the title;
- Since we already have a round avatar on the right, it is better to not use the round GitHub icon again on this side, so I chose to use text format.