### PR TITLE
feat: add skeleton loading & fix layout for login card

### DIFF
--- a/src/components/section/EventInfoHeader.tsx
+++ b/src/components/section/EventInfoHeader.tsx
@@ -76,24 +76,15 @@ export const EventInfoHeader: React.FC = () => {
               {formatOccurring(
                 occurringDaysArray ?? [],
                 event.type === "DAYSOFWEEK",
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 event.timeZone
               )}
             </div>
             <MdOutlineAccessTime className="ml-1" />
             <div>
-              {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                formatTimespan(event.begins, event.ends, event.timeZone)
-              }
+              {formatTimespan(event.begins, event.ends, event.timeZone)}
             </div>
             <IoEarthSharp className="ml-1" />
-            <div>
-              {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                formatTimeZoneTag(event.timeZone)
-              }
-            </div>
+            <div>{formatTimeZoneTag(event.timeZone)}</div>
           </div>
           <div className="text-3xl font-semibold">{event.name}</div>
           <div className="flex flex-row items-center gap-2 text-sm">

--- a/src/components/section/LogInCard.tsx
+++ b/src/components/section/LogInCard.tsx
@@ -21,50 +21,58 @@ export const LogInCard: React.FC = () => {
     .map((s: string) => new Date(s));
 
   return (
-    <div className="flex h-full w-full flex-row items-center justify-center p-4 pt-16">
+    <div className="flex h-full w-full grow flex-row items-center justify-center p-4">
       <div className="flex h-[600px] max-w-[750px] flex-1 items-center justify-center rounded-lg border-[1px] border-gray-300">
         <div className="my-10 flex h-full w-full flex-col">
-          <div className="flex w-full flex-col gap-2 border-b-[1px] border-gray-300 p-5">
-            <div className="flex flex-row items-center gap-1 text-sm text-gray-500">
-              <MdOutlineCalendarToday />
-              <div>
-                {event
-                  ? formatOccurring(
-                      occurringDaysArray ?? [],
-                      event.type === "DAYSOFWEEK",
-                      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                      event.timeZone
-                    )
-                  : "Loading..."}
+          {event ? (
+            <div className="flex w-full flex-col gap-2 border-b-[1px] border-gray-300 p-5">
+              <div className="flex flex-row items-center gap-1 text-sm text-gray-500">
+                <MdOutlineCalendarToday />
+                <div>
+                  {event
+                    ? formatOccurring(
+                        occurringDaysArray ?? [],
+                        event.type === "DAYSOFWEEK",
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                        event.timeZone
+                      )
+                    : "Loading..."}
+                </div>
+                <MdOutlineAccessTime className="ml-1" />
+                <div>
+                  {event
+                    ? // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                      formatTimespan(event.begins, event.ends, event.timeZone)
+                    : "Loading..."}
+                </div>
+                <HiOutlineGlobe className="ml-1" />
+                <div>
+                  {/* eslint-disable-next-line @typescript-eslint/no-unsafe-argument */}
+                  {event ? formatTimeZoneTag(event.timeZone) : "Loading..."}
+                </div>
               </div>
-              <MdOutlineAccessTime className="ml-1" />
-              <div>
-                {event
-                  ? // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    formatTimespan(event.begins, event.ends, event.timeZone)
-                  : "Loading..."}
+              <div className="text-3xl font-semibold text-black">
+                {event?.name ?? "Loading..."}
               </div>
-              <HiOutlineGlobe className="ml-1" />
-              <div>
-                {/* eslint-disable-next-line @typescript-eslint/no-unsafe-argument */}
-                {event ? formatTimeZoneTag(event.timeZone) : "Loading..."}
+              <div className="text-sm font-normal text-black">
+                {event &&
+                  (event._count.participant === 1 ? (
+                    <div>No one except host has filled yet</div>
+                  ) : (
+                    <div>
+                      {event._count.participant} people filled including host
+                    </div>
+                  ))}
+                {!event && "Loading..."}
               </div>
             </div>
-            <div className="text-3xl font-semibold text-black">
-              {event?.name ?? "Loading..."}
+          ) : (
+            <div className="flex flex-1 flex-col gap-2 border-b-[1px] border-gray-300 p-5">
+              <div className="skeleton h-5 max-w-[400px]" />
+              <div className="skeleton h-9 max-w-[600px]" />
+              <div className="skeleton h-5 max-w-[300px]" />
             </div>
-            <div className="text-sm font-normal text-black">
-              {event &&
-                (event._count.participant === 1 ? (
-                  <div>No one except host has filled yet</div>
-                ) : (
-                  <div>
-                    {event._count.participant} people filled including host
-                  </div>
-                ))}
-              {!event && "Loading..."}
-            </div>
-          </div>
+          )}
           <div className="flex h-full w-full flex-row items-center justify-center pb-7">
             <div className="flex w-full max-w-[350px] flex-col items-center justify-center gap-3 p-8">
               <div className="mb-2 text-sm text-gray-500">

--- a/src/components/section/LogInCard.tsx
+++ b/src/components/section/LogInCard.tsx
@@ -33,7 +33,6 @@ export const LogInCard: React.FC = () => {
                     ? formatOccurring(
                         occurringDaysArray ?? [],
                         event.type === "DAYSOFWEEK",
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                         event.timeZone
                       )
                     : "Loading..."}
@@ -41,13 +40,11 @@ export const LogInCard: React.FC = () => {
                 <MdOutlineAccessTime className="ml-1" />
                 <div>
                   {event
-                    ? // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                      formatTimespan(event.begins, event.ends, event.timeZone)
+                    ? formatTimespan(event.begins, event.ends, event.timeZone)
                     : "Loading..."}
                 </div>
                 <HiOutlineGlobe className="ml-1" />
                 <div>
-                  {/* eslint-disable-next-line @typescript-eslint/no-unsafe-argument */}
                   {event ? formatTimeZoneTag(event.timeZone) : "Loading..."}
                 </div>
               </div>

--- a/src/pages/event/[id].tsx
+++ b/src/pages/event/[id].tsx
@@ -46,7 +46,7 @@ const EventPage: NextPage = () => {
 
   if (!session) {
     return (
-      <div className="min-h-screen w-screen">
+      <div className="flex min-h-screen w-screen flex-col">
         <Navbar />
         <LogInCard />
         <Footer />


### PR DESCRIPTION
I forgot to add skeleton loading and adjust the login card layout for the footer in previous PRs. Now it looks like this:

<img width="600" alt="Screenshot 2023-06-30 at 9 55 45 AM" src="https://github.com/ParachuteTeam/Parachute/assets/30245379/f07a798a-84ad-489a-93d1-0d3e0ce686c6">
