### PR TITLE
fix: display error when selecting some dates

### DIFF
--- a/src/components/section/EventList.tsx
+++ b/src/components/section/EventList.tsx
@@ -7,7 +7,7 @@ import {
 } from "react-icons/md";
 import {
   formatOccurring,
-  formatTime,
+  formatTimeWithDay,
   formatTimeZoneTag,
 } from "../../utils/date-utils";
 import { IoEarthSharp } from "react-icons/io5";
@@ -59,8 +59,8 @@ const EventCard: React.FC<EventCardProps> = ({ event, myEvent }) => {
         <div className="flex flex-row items-center gap-1">
           <MdOutlineAccessTime className="ml-1" />
           <div>
-            {formatTime(event.begins, event.timeZone)} -{" "}
-            {formatTime(event.ends, event.timeZone)}
+            {formatTimeWithDay(event.begins, event.timeZone)} -{" "}
+            {formatTimeWithDay(event.ends, event.timeZone)}
           </div>
         </div>
         <div className="flex flex-row items-center gap-1">

--- a/src/components/ui/StyleScheduleSelector.tsx
+++ b/src/components/ui/StyleScheduleSelector.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { format } from "date-fns";
 import ScheduleSelector from "react-schedule-selector";
-import { formatTime } from "../../utils/date-utils";
+import { formatTimeWithoutDay } from "../../utils/date-utils";
 
 const TimeslotBlock: React.FC<{
   selected: boolean;
@@ -54,7 +54,7 @@ const TimeLabel: React.FC<{
 }> = ({ time }) => {
   return (
     <div className="relative bottom-[9px] w-16 text-right text-xs text-gray-500">
-      {time.getMinutes() % 30 == 0 ? formatTime(time) : ""}
+      {time.getMinutes() % 30 == 0 ? formatTimeWithoutDay(time) : ""}
     </div>
   );
 };

--- a/src/components/ui/StyleScheduleSelector.tsx
+++ b/src/components/ui/StyleScheduleSelector.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { format } from "date-fns";
 import ScheduleSelector from "react-schedule-selector";
-import { formatTimeWithoutDay } from "../../utils/date-utils";
+import { formatTime } from "../../utils/date-utils";
 
 const TimeslotBlock: React.FC<{
   selected: boolean;
@@ -54,7 +54,7 @@ const TimeLabel: React.FC<{
 }> = ({ time }) => {
   return (
     <div className="relative bottom-[9px] w-16 text-right text-xs text-gray-500">
-      {time.getMinutes() % 30 == 0 ? formatTimeWithoutDay(time) : ""}
+      {time.getMinutes() % 30 == 0 ? formatTime(time) : ""}
     </div>
   );
 };

--- a/src/components/ui/TimeSelector.tsx
+++ b/src/components/ui/TimeSelector.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from "react";
 import { addMinutes, isAfter, isBefore } from "date-fns";
 import {
-  formatTime,
+  formatTimeWithDay,
   formatTimeIdentifier,
   makeTime,
   parseTimeIdentifier,
@@ -39,7 +39,7 @@ export const TimeSelector: React.FC<TimeSelectorProps> = ({
   const options = useMemo(
     () =>
       availableTimes.map((time) => ({
-        label: formatTime(time, timeZone),
+        label: formatTimeWithDay(time, timeZone),
         value: formatTimeIdentifier(time, timeZone),
       })),
     [availableTimes, timeZone]

--- a/src/utils/date-utils.ts
+++ b/src/utils/date-utils.ts
@@ -141,6 +141,10 @@ export const formatTime = (time: Date, timeZoneTag = ""): string => {
   );
 };
 
+export const formatTimeWithoutDay = (time: Date, timeZoneTag = ""): string => {
+  return formatWithTimeZoneTag(time, timeZoneTag, "hh:mm aa");
+};
+
 export const formatTimespan = (
   begins: Date,
   ends: Date,

--- a/src/utils/date-utils.ts
+++ b/src/utils/date-utils.ts
@@ -134,6 +134,10 @@ export const toHourDecimal = (date: Date, timeZoneTag = ""): number => {
 };
 
 export const formatTime = (time: Date, timeZoneTag = ""): string => {
+  return formatWithTimeZoneTag(time, timeZoneTag, "hh:mm aa");
+};
+
+export const formatTimeWithDay = (time: Date, timeZoneTag = ""): string => {
   const plusDay = toPlusDay(time, timeZoneTag);
   return (
     formatWithTimeZoneTag(time, timeZoneTag, "hh:mm aa") +
@@ -141,16 +145,15 @@ export const formatTime = (time: Date, timeZoneTag = ""): string => {
   );
 };
 
-export const formatTimeWithoutDay = (time: Date, timeZoneTag = ""): string => {
-  return formatWithTimeZoneTag(time, timeZoneTag, "hh:mm aa");
-};
-
 export const formatTimespan = (
   begins: Date,
   ends: Date,
   timeZoneTag?: string
 ): string => {
-  return `${formatTime(begins, timeZoneTag)}-${formatTime(ends, timeZoneTag)}`;
+  return `${formatTimeWithDay(begins, timeZoneTag)}-${formatTimeWithDay(
+    ends,
+    timeZoneTag
+  )}`;
 };
 
 export const formatTimeIdentifier = (time: Date, timeZoneTag = ""): string => {


### PR DESCRIPTION
Simply fixes #83. We shouldn't attempt to add a plus day tag in time labels. If we do so, all "2nd" dates will be recognized as "+1d". Refer to the code for detailed fixes.

<img width="404" alt="Screenshot 2023-07-04 at 11 36 46 PM" src="https://github.com/ParachuteTeam/Parachute/assets/30245379/e59ae1eb-c2bc-42cd-81d9-4f657d50a1f5">

