### PR TITLE
fix: dashboard time display & create event loading

### DIFF
--- a/src/components/section/NewEventCard.tsx
+++ b/src/components/section/NewEventCard.tsx
@@ -46,8 +46,7 @@ const StartNewEventSection = () => {
 
   const canSubmit = eventName.trim().length > 0 && selectedDays.length > 0;
 
-  const { mutateAsync: createEvent, isLoading: creatingEvent } =
-    useCreateEvent();
+  const { mutateAsync: createEvent } = useCreateEvent();
   const handleCreateEvent = async () => {
     const { id: eventId } = await createEvent({
       occuringDays: selectedDays.toString(),
@@ -126,9 +125,8 @@ const StartNewEventSection = () => {
         className="primary-button mt-3 py-3 text-sm"
         loadingClassName="primary-button-loading mt-3 py-3 text-sm"
         disabledClassName="rounded-button-disabled mt-3 py-3 text-sm"
-        loading={creatingEvent}
         disabled={!canSubmit}
-        onClick={() => void handleCreateEvent()}
+        onClick={handleCreateEvent}
       >
         Create Event
       </ButtonWithState>

--- a/src/utils/date-utils.ts
+++ b/src/utils/date-utils.ts
@@ -60,6 +60,10 @@ export const offsetFromTimeZoneTag = (timeZoneTag?: string) => {
   return (Number(hours ?? 0) * 60 + Number(minutes ?? 0)) * 60 * 1000;
 };
 
+export const timeOriginalOffset = (time: Date) => {
+  return getTimezoneOffset(currentTimezone, time);
+};
+
 export const getInfoFromTimeZoneTag = (timeZoneTag: string) => {
   const [timeZone, gmt] = timeZoneTag.split(",");
   const offsetString = timeZoneTag.split("GMT")[1] ?? "";
@@ -73,13 +77,13 @@ export const getInfoFromTimeZoneTag = (timeZoneTag: string) => {
 
 export const toZonedTime = (time: Date, timeZoneTag: string) => {
   const offset = offsetFromTimeZoneTag(timeZoneTag);
-  const currentTimezoneOffset = offsetFromTimeZoneTag(currentTimezone);
+  const currentTimezoneOffset = timeOriginalOffset(time);
   return addMilliseconds(time, offset - currentTimezoneOffset);
 };
 
 export const toUTCTime = (time: Date, timeZoneTag: string) => {
   const offset = offsetFromTimeZoneTag(timeZoneTag);
-  const currentTimezoneOffset = offsetFromTimeZoneTag(currentTimezone);
+  const currentTimezoneOffset = timeOriginalOffset(time);
   return addMilliseconds(time, currentTimezoneOffset - offset);
 };
 


### PR DESCRIPTION
Checklist:

- [x] Time selectors on the dashboard now display the correct time range in timezones with daylight saving time, fixes #89
- [x] Create event loading animation will continue until the new page is loaded instead of ending a little bit earlier

Correct range:
<img width="398" alt="Screenshot 2023-09-05 at 2 02 16 PM" src="https://github.com/ParachuteTeam/Parachute/assets/30245379/8d71695d-448e-4061-b026-7674e0f27712">

Continue until the event detail page is shown (meaning that we will not see it ends on this page):
<img width="398" alt="Screenshot 2023-09-05 at 2 03 29 PM" src="https://github.com/ParachuteTeam/Parachute/assets/30245379/b5535f0a-7b96-4690-bf03-c5952015977f">
