### PR TITLE
feat(eventDetail)!: force desktop viewport

### DIFF
--- a/src/pages/event/[id].tsx
+++ b/src/pages/event/[id].tsx
@@ -8,6 +8,7 @@ import { OperationCard } from "../../components/section/OperationCard";
 import Footer from "../../components/section/Footer";
 import { ScreenLoading } from "../../components/ui/ScreenLoading";
 import { PrismaClient } from "@prisma/client";
+import Head from "next/head";
 
 export const getStaticPaths: GetStaticPaths = () => {
   return {
@@ -55,12 +56,17 @@ const EventPage: NextPage = () => {
   }
 
   return (
-    <div className="flex min-h-screen w-screen flex-col bg-gray-100">
-      <Navbar />
-      <EventInfoHeader />
-      <OperationCard />
-      <Footer />
-    </div>
+    <>
+      <Head>
+        <meta name="viewport" content="width=1024" />
+      </Head>
+      <div className="flex min-h-screen w-screen flex-col bg-gray-100">
+        <Navbar />
+        <EventInfoHeader />
+        <OperationCard />
+        <Footer />
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
Forces mobile users to have desktop viewport so detail page as least displays correctly.
<img width="2032" alt="Screenshot 2024-09-10 at 20 05 23" src="https://github.com/user-attachments/assets/8d061546-14d4-4635-adbc-ef02915025a4">
<img width="2032" alt="Screenshot 2024-09-10 at 20 05 36" src="https://github.com/user-attachments/assets/00927cae-e72b-46c8-8647-5db896775597">
