### PR TITLE
chore: remove unused console.log()

### DIFF
--- a/src/components/ui/DateSelect.tsx
+++ b/src/components/ui/DateSelect.tsx
@@ -106,7 +106,6 @@ export const DateSelect: React.FC<DateSelectProps> = ({
         }
       });
       onChange?.(valueCopy);
-      console.log(valueCopy);
     }
     setSelectionStart(null);
     setSelectionEnd(null);


### PR DESCRIPTION
Remove accidental `console.log()` for date picker